### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "build": "react-app-rewired build && yarn postinstall",
     "test": "react-app-rewired test --env=jsdom",
     "eject": "react-scripts eject",
-    "serve": "http-serve ./build --gzip",
-    "postinstall": "cp -r ./build/* $INIT_CWD/../platformio/EspJsonWs/data"
+    "serve": "http-serve ./build --gzip"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
Removed postinstall from package.json ... causes installation failure due to the fact that there is not a build folder. One could create the directory ... and touch a blank file to move on with the initial install ... but a different way should be devised to handle the file copying (something like that in the build_interface.py script from the esp8266-react project)